### PR TITLE
Exposes pages related methods

### DIFF
--- a/shim.coffee
+++ b/shim.coffee
@@ -102,6 +102,14 @@ pageWrap = (page) -> mkwrap page,
         cb = ->
 
     page.render file, opts; cb()
+  pages: (cb) ->
+    cb page.pages
+  pagesWindowName: (cb) ->
+    cb page.pagesWindowName
+  getPage: (windowName, cb) ->
+    cb page.getPage windowName
+  ownsPages: (cb) ->
+    cb page.ownsPages
   getContent: (cb=->) -> cb page.content
   getCookies: (cb=->) -> cb page.cookies
   renderBase64: (type, cb=->) -> cb page.renderBase64 type

--- a/shim.js
+++ b/shim.js
@@ -5554,6 +5554,18 @@ require.define("/shim.coffee", function (require, module, exports, __dirname, __
         page.render(file, opts);
         return cb();
       },
+      pages: function(cb) {
+        return cb(page.pages);
+      },
+      pagesWindowName: function(cb) {
+        return cb(page.pagesWindowName);
+      },
+      getPage: function(windowName, cb) {
+        return cb(page.getPage(windowName));
+      },
+      ownsPages: function(cb) {
+        return cb(page.ownsPages);
+      },
       getContent: function(cb) {
         if (cb == null) cb = function() {};
         return cb(page.content);

--- a/test/page.coffee
+++ b/test/page.coffee
@@ -43,6 +43,22 @@ describe "Pages",
         ph.createPage (page) =>
           @callback null, page, ph
 
+    "has a pages object":
+      topic: t (page) ->
+        page.pages (pages) =>
+          @callback null, pages
+
+      "that is empty to begin with": (pages) ->
+        assert.equal pages.length, 0
+
+    "can own pages":
+      topic: t (page) ->
+        page.ownsPages (status) =>
+          @callback null, status
+
+      "and owns itself to start": (status) ->
+        assert.equal status, true
+
     "can open a URL on localhost":
       topic: t (page) ->
         page.open "http://127.0.0.1:#{appServer.address().port}/", (status) =>


### PR DESCRIPTION
PhantomJS has several methods to deal with pages that are created dynamically by javascript. For instance, if your main page clicks on an anchor tag with a target, it essentially opens up a new tab that is owned by the parent.

This pull request exposes:
page.pages (an array of pages owned by the current page)
page.ownsPages (boolean)
page.pagesWindowName (array of names of windows)
page.getPage (returns a page owned by the current page, based on its windowName)

I added tests for page.pages and page.ownsPages, but not for getPage or pagesWindowName. I tried to figure out how to do it in CoffeeScript, but just couldn't grok it, sorry.

These are the related tests in PhantomJS: https://github.com/ariya/phantomjs/blob/fcdd274f2e8ef904e37795bd642a247a2a2e791c/test/webpage-spec.js#L1622-1824