### PR TITLE
fixed: don't assert child-process exit code

### DIFF
--- a/phantom.coffee
+++ b/phantom.coffee
@@ -97,7 +97,8 @@ module.exports =
           options.onExit code, signal
         else
           console.assert not signal?, "signal killed phantomjs: #{signal}"
-          console.assert code is 0, "abnormal phantomjs exit code: #{code}"
+          if code != 0
+            process.exit code
 
     sock = shoe (stream) ->
 

--- a/phantom.js
+++ b/phantom.js
@@ -160,7 +160,9 @@
             return options.onExit(code, signal);
           } else {
             console.assert(signal == null, "signal killed phantomjs: " + signal);
-            return console.assert(code === 0, "abnormal phantomjs exit code: " + code);
+            if (code !== 0) {
+              return process.exit(code);
+            }
           }
         });
       });


### PR DESCRIPTION
returning an exit code other than 0 is actually useful