### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,7 @@
     "bluebird": "~1.2.3",
     "phantomjs": "~1.9.7-5"
   },
-  "licenses": {
-    "type": "MIT",
-    "url": "http://www.opensource.org/licenses/MIT"
-  },
+  "license": "MIT",
   "scripts": {
     "test": "cake test"
   }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/