### PR TITLE
Add CI test for node `v4` and `latest`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,17 @@
 language: node_js
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 node_js:
   - "0.12"
   - "0.11"
   - "0.10"
   - "iojs"
   - "iojs-v1.0.4"
+  - "node"
+  - "4.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+# Add build chain config for Node GYP in Node 4.x
 env:
   - CXX=g++-4.8
 addons:


### PR DESCRIPTION
Added build chain config for Node GYP in Node 4.x so that `npm install` will succeed as per https://github.com/substack/dnode/pull/174