### PR TITLE
Process exits when there are no user defined signal handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "phantom",
   "description": "PhantomJS wrapper for Node",
   "homepage": "https://github.com/sgentle/phantomjs-node",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "repository": {
     "type": "git",
     "url": "git://github.com/sgentle/phantomjs-node.git"

--- a/phantom.coffee
+++ b/phantom.coffee
@@ -24,7 +24,6 @@ cleanUp = ->
 
 onSignalClean = (signal) ->
   return ->
-    cleanUp()
     if process.listeners(signal).length == 1
       process.exit(0)
 

--- a/phantom.coffee
+++ b/phantom.coffee
@@ -18,12 +18,18 @@ startPhantomProcess = (binary, port, hostname, args) ->
   ])
 
 # @Description: kills off all phantom processes within spawned by this parent process when it is exits
-onSignal = ->
+
+cleanUp = ->
   phantom.exit() for phantom in phanta
 
-process.on 'exit', onSignal
-process.on 'SIGINT', onSignal
-process.on 'SIGTERM', onSignal
+onSignalClean = (signal) ->
+  return ->
+    cleanUp()
+    if process.listeners(signal).length == 1
+      process.exit(0)
+
+process.on('exit', cleanUp)
+process.on(signal, onSignalClean(signal)) for signal in ['SIGINT', 'SIGTERM']
 
 # @Description: We need this because dnode does magic clever stuff with functions, but we want the function to make it intact to phantom
 wrap = (ph) ->

--- a/test/closing.coffee
+++ b/test/closing.coffee
@@ -1,0 +1,73 @@
+vows    = require 'vows'
+child_process   = require 'child_process'
+exec = child_process.exec
+spawn = child_process.spawn
+assert = require 'assert'
+
+describe = (name, bat) -> vows.describe(name).addBatch(bat).export(module)
+
+t = (fn) ->
+  ->
+    fn.apply this, arguments
+    return
+
+program = "var phantom = require('./'); process.on('SIGINT', function() {  console.log('SIGINT'); process.exit(0); }); process.on('SIGTERM', function() { console.log('SIGTERM'); process.exit(0); }); process.on('exit', function() { console.log('EXIT'); }); console.log('Setup'); setTimeout(function() { console.log('Going out'); }, 1000);"
+
+programCbless = "var phantom = require('./'); console.log('Setup'); setTimeout(function() { console.log('Going out'); }, 200);"
+
+createTopic = (signal, p) ->
+  ->
+    that = this
+    result = ''
+    co = child_process.exec 'node -e "' + p + '"'
+    cb = ->
+    if signal
+      cb = ->
+          process.kill co.pid, signal
+    else
+      cb = ->
+
+    co.stdout.on 'data', (data) ->
+      result += data
+      cb() if data.toString().match /^Setup/g
+    co.stderr.on 'data', (data) ->
+      result += data
+    co.on 'exit', (code) ->
+      that.callback null, [result, co.pid]
+    return undefined
+
+createExitTest = (expect) ->
+  (err, [r, pid]) ->
+    assert.isNull err
+    assert.deepEqual('Setup\n' + expect, r)
+
+createExitTestCbLess = (expect) ->
+  (err, [r, pid]) ->
+    assert.isNull err
+    assert.deepEqual('Setup\n' + expect, r)
+    try
+      process.kill(pid)
+      assert.fail()
+
+describe "The phantom module",
+  "SIGINT":
+    "with callbacks":
+      topic: createTopic('SIGINT', program)
+      "exited": createExitTest('SIGINT\nEXIT\n')
+    "without callbacks":
+      topic: createTopic('SIGINT', programCbless)
+      "exited": createExitTestCbLess('')
+  "SIGTERM":
+    "with callbacks":
+      topic: createTopic('SIGTERM', program)
+      "exited": createExitTest('SIGTERM\nEXIT\n')
+    "without callbacks":
+      topic: createTopic('SIGTERM', programCbless)
+      "exited": createExitTestCbLess('')
+  "without signals":
+    "with callbacks":
+      topic: createTopic(false, program)
+      "exited": createExitTest('Going out\nEXIT\n')
+    "without callbacks":
+      topic: createTopic(false, programCbless)
+      "exited": createExitTestCbLess('Going out\n')


### PR DESCRIPTION
Following #316, with @jazzzz input, a process should exit on ``` SIGINT ```.

With this, phantom will run ``` process.exit ``` if the only callbacks for signals are its own.